### PR TITLE
Show placeholder image if item image is empty

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -8,6 +8,7 @@ import {
   ITEM_PAGE_LOADED,
   ITEM_PAGE_UNLOADED,
 } from "../../constants/actionTypes";
+import { PLACEHOLDER_IMG } from "../../constants/defaults";
 
 const mapStateToProps = (state) => ({
   ...state.item,
@@ -50,7 +51,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || PLACEHOLDER_IMG}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -17,6 +17,7 @@ const mapDispatchToProps = (dispatch) => ({
     }),
 });
 
+const PLACEHOLDER_IMG = "placeholder.png";
 const ItemPreview = (props) => {
   const item = props.item;
 
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || PLACEHOLDER_IMG}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
+import { PLACEHOLDER_IMG } from "../constants/defaults";
 
 const mapDispatchToProps = (dispatch) => ({
   favorite: (slug) =>
@@ -17,7 +18,6 @@ const mapDispatchToProps = (dispatch) => ({
     }),
 });
 
-const PLACEHOLDER_IMG = "placeholder.png";
 const ItemPreview = (props) => {
   const item = props.item;
 

--- a/frontend/src/constants/defaults.js
+++ b/frontend/src/constants/defaults.js
@@ -1,0 +1,1 @@
+export const PLACEHOLDER_IMG = "placeholder.png";

--- a/frontend/src/constants/defaults.js
+++ b/frontend/src/constants/defaults.js
@@ -1,1 +1,1 @@
-export const PLACEHOLDER_IMG = "placeholder.png";
+export const PLACEHOLDER_IMG = "/placeholder.png";


### PR DESCRIPTION
Fix displaying a placeholder image if a catalogue item image is empty by adding an OR to the image src in both the list view and the Item info view.

List view:

![image](https://user-images.githubusercontent.com/68463406/178825554-908472a2-5ebf-4dfb-8716-ba3aa340f7ca.png)

Item view:

![image](https://user-images.githubusercontent.com/68463406/178825684-182c0805-e028-4825-8f0a-f82f6f7b3ff6.png)

