### PR TITLE
Add missing image attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/venv
 /backend/node_modules
 /frontend/node_modules
 /.wilco-helpers/node_modules

--- a/backend/app/db/queries/tables.py
+++ b/backend/app/db/queries/tables.py
@@ -43,6 +43,7 @@ class Items(TypedTable):
     title: str
     description: str
     body: str
+    image: str
     seller_id: int
     created_at: datetime
     updated_at: datetime

--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -21,7 +21,7 @@ from app.models.domain.users import User
 
 SELLER_USERNAME_ALIAS = "seller_username"
 SLUG_ALIAS = "slug"
-PLACEHOLDER_IMG = "/placeholder.jpg"
+PLACEHOLDER_IMG = "/placeholder.png"
 
 CAMEL_OR_SNAKE_CASE_TO_WORDS = r"^[a-z\d_\-]+|[A-Z\d_\-][^A-Z\d_\-]*"
 
@@ -40,7 +40,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
         description: str,
         seller: User,
         body: Optional[str] = None,
-        image: str = PLACEHOLDER_IMG,
+        image: Optional[str] = None,
         tags: Optional[Sequence[str]] = None,
     ) -> Item:
         async with self.connection.transaction():
@@ -51,7 +51,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
                 description=description,
                 body=body,
                 seller_username=seller.username,
-                image=image
+                image=image or PLACEHOLDER_IMG
             )
 
             if tags:

--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -21,6 +21,7 @@ from app.models.domain.users import User
 
 SELLER_USERNAME_ALIAS = "seller_username"
 SLUG_ALIAS = "slug"
+PLACEHOLDER_IMG = "/placeholder.jpg"
 
 CAMEL_OR_SNAKE_CASE_TO_WORDS = r"^[a-z\d_\-]+|[A-Z\d_\-][^A-Z\d_\-]*"
 
@@ -39,7 +40,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
         description: str,
         seller: User,
         body: Optional[str] = None,
-        image: Optional[str] = None,
+        image: str = PLACEHOLDER_IMG,
         tags: Optional[Sequence[str]] = None,
     ) -> Item:
         async with self.connection.transaction():


### PR DESCRIPTION
Add missing `image` attribute to `Items` table and store placeholder URL if not provided when creating an image.

The image attribute was missing from the Items table in the backend, causing an empty string to be returned for any item in the catalogue.

Moreover, clients requested for the API to also return the URL of the placeholder image if no image was assigned to an item.