### PR TITLE
Fix styling to reduce user dropouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ yarn-error.log*
 
 #IDEs
 /.idea/
+
+venv

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -56,6 +56,14 @@ body {
   -webkit-box-orient: vertical;
 }
 
-.user-info {
-  min-width: 800px;
+a {
+  color: #af93f2;
+
+  &:hover {
+    color: #f2f2f2;
+  }
+}
+
+.nav-tabs .nav-link.active {
+  color: #d0d0d0;
 }


### PR DESCRIPTION
Some bad styling caused mobile users to drop out of our website. This PR fixes the colour of links (which before was very hard to read) and eliminates the overflowing `user-info` section.

**Before**:

<img alt="Screen Shot 2022-09-18 at 13 17 29" src="https://user-images.githubusercontent.com/68463406/190899407-25bd1667-92bf-43d6-8037-864dc2e9f59f.png" width="40%" />

**After**:

<img alt="Screen Shot 2022-09-18 at 13 16 11" src="https://user-images.githubusercontent.com/68463406/190899340-7334b876-50e5-4db5-9083-13570410112e.png" width="40%" />
